### PR TITLE
Remove Coverpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       name: 'Flow Launcher',
       repo: 'Flow-Launcher/Flow.Launcher',
       relativePath: true,
-      coverpage: true,
+      coverpage: false,
       mergeNavbar: true,
       loadSidebar: true,
       subMaxLevel: 4,


### PR DESCRIPTION

![image](https://github.com/Flow-Launcher/docs/assets/6903107/5ee07865-288e-4447-aa2a-01c92548e0b6)


Since that area always appears as a full screen, it is often not known that it is a document screen.