### PR TITLE
Fix an error when searching the plugin list if a description or an author field doesn't exist

### DIFF
--- a/webcomponents/src/components/PluginDisplay.svelte
+++ b/webcomponents/src/components/PluginDisplay.svelte
@@ -13,9 +13,9 @@ export let plugin: FlowPlugin;
       </a>
     </div>
   </td>
-  <td>{plugin.Description}</td>
-  <td>{plugin.Author}</td>
-  <td>{plugin.Version}</td>
+  <td>{plugin.Description ?? ""}</td>
+  <td>{plugin.Author ?? ""}</td>
+  <td>{plugin.Version ?? ""}</td>
 </tr>
 
 <style>

--- a/webcomponents/src/webcomponents/PluginDirectory.svelte
+++ b/webcomponents/src/webcomponents/PluginDirectory.svelte
@@ -57,7 +57,7 @@ $: {
       if (trimmedSearch.length === 0) {
         return true;
       }
-      return v.Name.toLowerCase().includes(trimmedSearch) || v.Description.toLowerCase().includes(trimmedSearch) || v.Author.toLowerCase().includes(trimmedSearch);
+      return v.Name.toLowerCase().includes(trimmedSearch) || v.Description?.toLowerCase().includes(trimmedSearch) || v.Author?.toLowerCase().includes(trimmedSearch);
     })
     .sort((a, b) => {
       switch (sorting) {
@@ -66,9 +66,9 @@ $: {
         case 'nameDesc':
           return b.Name.localeCompare(a.Name);
         case 'authorAsc':
-          return a.Author.localeCompare(b.Author);
+          return a.Author?.localeCompare(b?.Author) ?? -1;
         case 'authorDesc':
-          return b.Author.localeCompare(a.Author);
+          return b.Author?.localeCompare(a?.Author) ?? 1;
         case 'dateAsc':
           return a.DateAdded.localeCompare(b.DateAdded);
         case 'dateDesc':


### PR DESCRIPTION
Currently, there's one plugin with the misspelled `Description` field, which caused the error to happen: [Cursor Workspace](https://github.com/cou723/Flow.Plugin.CursorWorkspace) forked from @taooceros's [VS Code Workspace](https://github.com/taooceros/Flow.Plugin.VSCodeWorkspace). VS Code Workspace seems to have the same issue in the source code, but not in the plugin store.