### PR TITLE
Fix a link to the visual editor not actually leading anywhere

### DIFF
--- a/json-rpc-settings.md
+++ b/json-rpc-settings.md
@@ -184,7 +184,7 @@ body:
 <settings-component-demo type="checkbox" label="Prefer shorter answers" description="If checked, the plugin will try to give answer much shorter than the usual ones."></settings-component-demo>
 
 ### Visual editor for `SettingsTemplate.yaml`
-You can use a [visual editor](#/json-rpc-visual-settingstemplate-editor) for creating the `SettingsTemplate.yaml` file. When you're done editing, click the `Generate SettingsTemplate.yaml` file and copy-paste its contents into your `SettingsTemplate.yaml` file. Optionally, you can also copy the generated typings for your settings object in your preferred programming language.
+You can use a [visual editor](/json-rpc-visual-settingstemplate-editor.md) for creating the `SettingsTemplate.yaml` file. When you're done editing, click the `Generate SettingsTemplate.yaml` file and copy-paste its contents into your `SettingsTemplate.yaml` file. Optionally, you can also copy the generated typings for your settings object in your preferred programming language.
 
 <script>
 const element = document.querySelector('#__settings-script__');


### PR DESCRIPTION
Before this change, it tried to scroll to an element with `id="/json-rpc-visual-settingstemplate-editor"` on the same page. Now it correctly leads to the visual editor page. The link in the sidebar is correct, so no changes necessary there.