### PR TITLE
Add information on using JSON schemas

### DIFF
--- a/json-rpc-settings.md
+++ b/json-rpc-settings.md
@@ -183,6 +183,13 @@ body:
 <settings-component-demo type="dropdown" label="Programming language to prefer for answers" value="TypeScript" options='["JavaScript", "TypeScript", "Python", "C#"]'></settings-component-demo>
 <settings-component-demo type="checkbox" label="Prefer shorter answers" description="If checked, the plugin will try to give answer much shorter than the usual ones."></settings-component-demo>
 
+### JSON Schema
+Add the following line at the beginning of your `SettingsTemplate.yaml` file to enable validation and auto-completion in your IDE. Unfortunately, this feature is supported only in JetBrains IDEs (WebStorm, PhpStorm, Rider, etc.) and does not work in Visual Studio or Visual Studio Code. Please note that it must start with `#` as it must be a comment, otherwise Flow Launcher won't be able to parse the file.
+
+```yaml
+#$schema: https://www.flowlauncher.com/schemas/settings-template.schema.json
+```
+
 ### Visual editor for `SettingsTemplate.yaml`
 You can use a [visual editor](/json-rpc-visual-settingstemplate-editor.md) for creating the `SettingsTemplate.yaml` file. When you're done editing, click the `Generate SettingsTemplate.yaml` file and copy-paste its contents into your `SettingsTemplate.yaml` file. Optionally, you can also copy the generated typings for your settings object in your preferred programming language.
 

--- a/plugin.json.md
+++ b/plugin.json.md
@@ -17,3 +17,16 @@ It must be in the plugin root directory.
   "ExecuteFileName":"" //Execution entry. dll extension for C#/F# plugin, .py for python plugin, .js/.ts for JS/TS plugins and .exe or other executable for executable plugin. Path examples include "main.py" or "./dist/main.js"
 }
 ```
+
+## JSON Schema 
+Additionally, you can add a property called `$schema` to enable validation and auto-completion in your IDE. This works in JetBrains IDEs (i.e., WebStorm, PhpStorm, Rider, etc.), Visual Studio, and Visual Studio Code. Add this property to the top of the JSON file:
+
+```js
+{
+  "$schema": "https://www.flowlauncher.com/schemas/plugin.schema.json",
+  // the rest of the plugin.json file
+  // ...
+}
+```
+
+Now you should have auto-completion and file validation available for you in your IDE.


### PR DESCRIPTION
This PR adds information on using JSON schemas for IDE validation and auto-complete in `plugin.json` and `SettingsTemplate.yaml` files.